### PR TITLE
Teacher can see student names throughout the chat

### DIFF
--- a/src/components/pages/TeachersPage/AllStudentChatsDisplay.tsx
+++ b/src/components/pages/TeachersPage/AllStudentChatsDisplay.tsx
@@ -29,7 +29,7 @@ export default function AllStudentChatsDisplay({
             item
             xs={12}
             md={6}
-            lg={3}
+            lg={4}
             sx={{
               cursor: 'pointer',
             }}

--- a/src/components/pages/TeachersPage/Chatbox.css.tsx
+++ b/src/components/pages/TeachersPage/Chatbox.css.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 
 const chatboxContainer = css`
-  max-width: 500px;
+  max-width: 600px;
 `;
 
 const chatboxTop = css`

--- a/src/components/pages/TeachersPage/Conversation.css.tsx
+++ b/src/components/pages/TeachersPage/Conversation.css.tsx
@@ -21,6 +21,11 @@ const teacher = css`
   color: purple;
 `;
 
+const lessImportantText = css`
+  font-style: italic;
+  color: gray;
+`;
+
 const msg = css`
   word-break: break-word;
 `;
@@ -31,6 +36,7 @@ const conversationCSS = {
   student2,
   teacher,
   msg,
+  lessImportantText,
 };
 
 export default conversationCSS;

--- a/src/components/pages/TeachersPage/Conversation.tsx
+++ b/src/components/pages/TeachersPage/Conversation.tsx
@@ -31,12 +31,18 @@ export default function Conversation({ chat, inAllStudentChatsDisplay }) {
       </Box>
       {chat.conversation.map(([person, character, message], i) => {
         let fontCSS = {};
-        if (person === 'student1') fontCSS = conversationCSS.student1;
-        else if (person === 'student2') fontCSS = conversationCSS.student2;
-        else if (person === 'teacher') fontCSS = conversationCSS.teacher;
+        let realName = '';
+        if (person === 'student1') {
+          fontCSS = conversationCSS.student1;
+          realName = student1.realName;
+        } else if (person === 'student2') {
+          fontCSS = conversationCSS.student2;
+          realName = student2.realName;
+        } else if (person === 'teacher') fontCSS = conversationCSS.teacher;
 
         return (
           <Typography key={i}>
+            {`(${realName}) `}
             <span css={fontCSS}>{filterWords(character)}: </span>
             <span css={conversationCSS.msg}>{filterWords(message)}</span>
           </Typography>

--- a/src/components/pages/TeachersPage/Conversation.tsx
+++ b/src/components/pages/TeachersPage/Conversation.tsx
@@ -19,11 +19,10 @@ export default function Conversation({ chat, inAllStudentChatsDisplay }) {
       <Box css={conversationCSS.introText}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
           <Box>
-            <span css={conversationCSS.student1}>{student1.realName}</span> (
-            {student1.character})
-            <br />
-            <span css={conversationCSS.student2}>{student2.realName}</span> (
-            {student2.character})
+            ({student1.realName})&nbsp;&nbsp;
+            <span css={conversationCSS.student1}>{student1.character}</span>
+            <br />({student2.realName})&nbsp;&nbsp;
+            <span css={conversationCSS.student2}>{student2.character}</span>
           </Box>
           <span>{chat.startTime}</span>
         </Box>
@@ -42,7 +41,9 @@ export default function Conversation({ chat, inAllStudentChatsDisplay }) {
 
         return (
           <Typography key={i}>
-            {`(${realName}) `}
+            <span css={conversationCSS.lessImportantText}>
+              {realName}&nbsp;&nbsp;
+            </span>
             <span css={fontCSS}>{filterWords(character)}: </span>
             <span css={conversationCSS.msg}>{filterWords(message)}</span>
           </Typography>


### PR DESCRIPTION
Allows the teacher to see all the students by name throughout the chat without the teacher having to scroll up to the top. Closes #43

![image](https://github.com/mssiegel/Frempco-web-client/assets/29524485/a2ee485e-7e19-4ada-aef5-c003eee98c95)