### PR TITLE
Prevents scrolling to the displayed chat on teachers page

### DIFF
--- a/src/components/pages/StudentsPage/Conversation.tsx
+++ b/src/components/pages/StudentsPage/Conversation.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef } from 'react';
 
 import conversationCSS from './Conversation.css';
 import { filterWords } from '@utils/classrooms';
-import { scrollDown } from '@utils/classrooms';
+import { scrollSlowlyIntoView } from '@utils/classrooms';
 
 export default function Conversation({ socket, chat, setChat }) {
   const lastMessage = useRef(null);
@@ -34,7 +34,8 @@ export default function Conversation({ socket, chat, setChat }) {
   }, [setChat, socket]);
 
   useEffect(() => {
-    scrollDown(lastMessage);
+    // Scrolling slowly provides a smooth visual effect for displaying new messages
+    scrollSlowlyIntoView(lastMessage);
   }, [chat.conversation]);
 
   return (

--- a/src/components/pages/TeachersPage/Chatbox.tsx
+++ b/src/components/pages/TeachersPage/Chatbox.tsx
@@ -1,7 +1,9 @@
 /** @jsxImportSource @emotion/react */
 
 import { Box } from '@mui/material';
+import { useRef, useEffect } from 'react';
 
+import { displayBottomOfElement } from '@utils/classrooms';
 import chatboxCSS from './Chatbox.css';
 import Conversation from './Conversation';
 import CopyButton from '@components/shared/CopyButton';
@@ -14,6 +16,12 @@ export default function Chatbox({
   inAllStudentChatsDisplay,
   setStudentChats,
 }) {
+  useEffect(() => {
+    displayBottomOfElement(chatboxConversationContainer);
+  }, [chat.conversation]);
+
+  const chatboxConversationContainer = useRef(null);
+
   return (
     <Box css={chatboxCSS.chatboxContainer}>
       {!inAllStudentChatsDisplay && <CopyButton elementId='displayed-chat' />}
@@ -24,11 +32,9 @@ export default function Chatbox({
             ? '6px solid royalblue'
             : ''
         }
+        ref={chatboxConversationContainer}
       >
-        <Conversation
-          chat={chat}
-          inAllStudentChatsDisplay={inAllStudentChatsDisplay}
-        />
+        <Conversation chat={chat} />
       </Box>
 
       {/* Include send messages component if its the primary displayed chat */}

--- a/src/components/pages/TeachersPage/Conversation.tsx
+++ b/src/components/pages/TeachersPage/Conversation.tsx
@@ -37,7 +37,7 @@ export default function Conversation({ chat }) {
             {/* Only students have real names; teacher does not */}
             {realName && (
               <span css={conversationCSS.lessImportantText}>
-                {realName} &nbsp;&nbsp;
+                {realName}&nbsp;&nbsp;
               </span>
             )}
             <span css={fontCSS}>{filterWords(character)}: </span>

--- a/src/components/pages/TeachersPage/Conversation.tsx
+++ b/src/components/pages/TeachersPage/Conversation.tsx
@@ -1,18 +1,11 @@
 /** @jsxImportSource @emotion/react */
-import { useRef, useEffect } from 'react';
-
 import { Box, Typography } from '@mui/material';
 
 import conversationCSS from './Conversation.css';
-import { filterWords, scrollDown } from '@utils/classrooms';
+import { filterWords } from '@utils/classrooms';
 
-export default function Conversation({ chat, inAllStudentChatsDisplay }) {
+export default function Conversation({ chat }) {
   const [student1, student2] = chat.studentPair;
-  const lastMessage = useRef(null);
-
-  useEffect(() => {
-    if (!inAllStudentChatsDisplay) scrollDown(lastMessage);
-  }, [chat.conversation, inAllStudentChatsDisplay]);
 
   return (
     <Box id='displayed-chat'>
@@ -41,16 +34,17 @@ export default function Conversation({ chat, inAllStudentChatsDisplay }) {
 
         return (
           <Typography key={i}>
-            <span css={conversationCSS.lessImportantText}>
-              {realName}&nbsp;&nbsp;
-            </span>
+            {/* Only students have real names; teacher does not */}
+            {realName && (
+              <span css={conversationCSS.lessImportantText}>
+                {realName} &nbsp;&nbsp;
+              </span>
+            )}
             <span css={fontCSS}>{filterWords(character)}: </span>
             <span css={conversationCSS.msg}>{filterWords(message)}</span>
           </Typography>
         );
       })}
-
-      <span ref={lastMessage} />
     </Box>
   );
 }

--- a/src/utils/classrooms.tsx
+++ b/src/utils/classrooms.tsx
@@ -27,7 +27,16 @@ export function filterWords(words: string) {
   }
 }
 
-export function scrollDown(refObject) {
+export function displayBottomOfElement(refObject) {
+  // used to display the bottom of a chatbox whenever a new message comes in
+  // used on pages with multiple chatboxes, i.e. teachers page
+  refObject.current.scrollTop = refObject.current.scrollHeight;
+}
+
+export function scrollSlowlyIntoView(refObject) {
+  // used to display the bottom of a chatbox whenever a new message comes in
+  // used on pages with only one chatbox, i.e. students page
+  // do not use this function on pages with multiple chatboxes as then it'd scroll other chatboxes into view whenever a new message arrives
   if (refObject.current)
     refObject.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
 }


### PR DESCRIPTION
Closes #50 
- added new utility function to display the bottom of each chatbox conversation on teachers page without doing any scrolling
- scrolling on students page remains the same as previously given their is only one chatbox on students page