### PR TITLE
Fixes bug on unpaired student order

### DIFF
--- a/src/components/pages/TeachersPage/UnpairedStudentItem.tsx
+++ b/src/components/pages/TeachersPage/UnpairedStudentItem.tsx
@@ -22,7 +22,7 @@ export default function UnpairedStudentItem({
       else if (student2Index === unpaired.length) student2Index = 0;
 
       swap(unpaired, student1Index, student2Index);
-      setUnpairedStudents(unpaired);
+      return unpaired;
     });
   }
 

--- a/src/components/pages/TeachersPage/UnpairedStudentsList.tsx
+++ b/src/components/pages/TeachersPage/UnpairedStudentsList.tsx
@@ -76,8 +76,8 @@ export default function UnpairedStudentsList({
     }
     socket.emit('pair students', { studentPairs });
 
-    // remove the two unpaired students
     if (studentIndex !== undefined) {
+      // remove the two newly paired students from unpaired list
       const newUnpairedStudents = [...unpairedStudents];
       newUnpairedStudents.splice(studentIndex, 2);
       setUnpairedStudents(newUnpairedStudents);


### PR DESCRIPTION
Fixes bug when teacher clicks arrow to move an unpaired student up or down.  This bug only shows in development mode and not on production. The issue was the React code was not properly returning the new state from the setState function.