### PR TITLE
Moved DevLinkShortcuts to top of homepage

### DIFF
--- a/src/components/pages/HomePage/DevLinkShortcuts.tsx
+++ b/src/components/pages/HomePage/DevLinkShortcuts.tsx
@@ -27,7 +27,7 @@ export default function DevLinkShortcuts({
 
   return (
     <>
-      <Typography variant='h5' sx={{ m: 3, mt: 10, color: 'gray' }}>
+      <Typography variant='h5' sx={{ mb: 3, color: 'gray' }}>
         These link shortcuts only appear in the development environment:
       </Typography>
       <Typography variant='h5' sx={{ m: 3 }}>

--- a/src/components/pages/HomePage/index.tsx
+++ b/src/components/pages/HomePage/index.tsx
@@ -41,6 +41,13 @@ export default function HomePage() {
 
   return (
     <main>
+      {process.env.NEXT_PUBLIC_NODE_ENV === 'development' && (
+        <DevLinkShortcuts
+          visitTeachersPage={visitTeachersPage}
+          visitStudentsPage={visitStudentsPage}
+        />
+      )}
+
       <Grid container color={(theme) => theme.palette.common.white}>
         <Grid item md={12} p={2}>
           <Typography variant='h3' textAlign='left' mb={6}>
@@ -192,13 +199,6 @@ export default function HomePage() {
           </Link>
         </Typography>
       </Box>
-
-      {process.env.NEXT_PUBLIC_NODE_ENV === 'development' && (
-        <DevLinkShortcuts
-          visitTeachersPage={visitTeachersPage}
-          visitStudentsPage={visitStudentsPage}
-        />
-      )}
     </main>
   );
 }


### PR DESCRIPTION
Having the shortcut links on top of the homepage will make them easier to click when developing.