### PR TITLE
Prevents keyboard from closing on mobile

### DIFF
--- a/src/components/pages/StudentsPage/SendMessages.tsx
+++ b/src/components/pages/StudentsPage/SendMessages.tsx
@@ -2,12 +2,14 @@
 
 import { Box, Fab, Typography } from '@mui/material';
 import { Send as SendIcon } from '@mui/icons-material';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { filterWords } from '@utils/classrooms';
 import sendMessagesCSS from './SendMessages.css';
 
 let peerTypingTimer = null;
 export default function SendMessages({ socket, chat, setChat }) {
+  const typeMessageInput = useRef(null);
+
   const [message, setMessage] = useState('');
   const [chatEndedMsg, setChatEndedMsg] = useState(null);
   const [peerIsTyping, setPeerIsTyping] = useState(false);
@@ -57,6 +59,7 @@ export default function SendMessages({ socket, chat, setChat }) {
         conversation: [...chat.conversation, ['you', chat.you, message]],
       }));
       setMessage('');
+      typeMessageInput.current.focus();
 
       if (socket) {
         socket.emit('student sent message', {
@@ -96,6 +99,7 @@ export default function SendMessages({ socket, chat, setChat }) {
             maxLength={75}
             onChange={sendUserIsTyping}
             autoFocus
+            ref={typeMessageInput}
           />
 
           <Fab

--- a/src/utils/classrooms.tsx
+++ b/src/utils/classrooms.tsx
@@ -38,7 +38,7 @@ export function scrollSlowlyIntoView(refObject) {
   // used on pages with only one chatbox, i.e. students page
   // do not use this function on pages with multiple chatboxes as then it'd scroll other chatboxes into view whenever a new message arrives
   if (refObject.current)
-    refObject.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    refObject.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
 export interface ClassroomProps {


### PR DESCRIPTION
If the user sends a chat message by clicking the submit button on mobile, we want the input to still be in focus. Because when the input is in focus the keyboard is displayed and the user can type out another message.   Now the input will remain in focus after sending a chat message.