### PR TITLE
Adds *accurate* smooth scrolling to all chatboxes

### DIFF
--- a/pages/styles.css
+++ b/pages/styles.css
@@ -8,7 +8,7 @@ platforms (Makes windows scrollbars prettier) */
 
 /* Handle */
 ::-webkit-scrollbar-thumb {
-  background: rgba(128, 128, 128, 0.175);
+  background: rgba(128, 128, 128, 0.375);
   border-radius: 10px;
 }
 

--- a/src/components/pages/StudentsPage/Chatbox.css.tsx
+++ b/src/components/pages/StudentsPage/Chatbox.css.tsx
@@ -16,6 +16,7 @@ const chatboxTop = css`
   padding: 10px 10px 0 10px;
   max-height: 260px;
   overflow-y: overlay;
+  scroll-behavior: smooth;
 `;
 
 const chatboxBottom = css`

--- a/src/components/pages/StudentsPage/Chatbox.tsx
+++ b/src/components/pages/StudentsPage/Chatbox.tsx
@@ -1,17 +1,25 @@
 /** @jsxImportSource @emotion/react */
 
 import { Box } from '@mui/material';
+import { useEffect, useRef } from 'react';
 
+import { scrollToBottomOfElement } from '@utils/classrooms';
 import chatboxCSS from './Chatbox.css';
 import Conversation from './Conversation';
 import SendMessages from './SendMessages';
 import CopyButton from '@components/shared/CopyButton';
 
 export default function Chatbox({ socket, chat, setChat }) {
+  useEffect(() => {
+    scrollToBottomOfElement(chatboxConversationContainer);
+  }, [chat.conversation]);
+
+  const chatboxConversationContainer = useRef(null);
+
   return (
     <Box css={chatboxCSS.chatboxContainer}>
       <CopyButton elementId='conversation' />
-      <Box css={chatboxCSS.chatboxTop}>
+      <Box css={chatboxCSS.chatboxTop} ref={chatboxConversationContainer}>
         <Conversation socket={socket} chat={chat} setChat={setChat} />
       </Box>
       <Box css={chatboxCSS.chatboxBottom}>

--- a/src/components/pages/StudentsPage/Conversation.tsx
+++ b/src/components/pages/StudentsPage/Conversation.tsx
@@ -1,14 +1,12 @@
 /** @jsxImportSource @emotion/react */
 
 import { Box, Typography } from '@mui/material';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 import conversationCSS from './Conversation.css';
 import { filterWords } from '@utils/classrooms';
-import { scrollSlowlyIntoView } from '@utils/classrooms';
 
 export default function Conversation({ socket, chat, setChat }) {
-  const lastMessage = useRef(null);
   useEffect(() => {
     if (socket) {
       socket.on('student sent message', ({ character, message }) => {
@@ -32,11 +30,6 @@ export default function Conversation({ socket, chat, setChat }) {
       }
     };
   }, [setChat, socket]);
-
-  useEffect(() => {
-    // Scrolling slowly provides a smooth visual effect for displaying new messages
-    scrollSlowlyIntoView(lastMessage);
-  }, [chat.conversation]);
 
   return (
     <Box id='conversation'>
@@ -63,8 +56,6 @@ export default function Conversation({ socket, chat, setChat }) {
           </Typography>
         );
       })}
-
-      <span ref={lastMessage} />
     </Box>
   );
 }

--- a/src/components/pages/TeachersPage/Chatbox.css.tsx
+++ b/src/components/pages/TeachersPage/Chatbox.css.tsx
@@ -11,6 +11,7 @@ const chatboxTop = css`
   padding: 10px;
   max-height: 260px;
   overflow-y: overlay;
+  scroll-behavior: smooth;
 `;
 
 const chatboxBottom = css`

--- a/src/components/pages/TeachersPage/Chatbox.tsx
+++ b/src/components/pages/TeachersPage/Chatbox.tsx
@@ -3,7 +3,7 @@
 import { Box } from '@mui/material';
 import { useRef, useEffect } from 'react';
 
-import { displayBottomOfElement } from '@utils/classrooms';
+import { scrollToBottomOfElement } from '@utils/classrooms';
 import chatboxCSS from './Chatbox.css';
 import Conversation from './Conversation';
 import CopyButton from '@components/shared/CopyButton';
@@ -17,7 +17,7 @@ export default function Chatbox({
   setStudentChats,
 }) {
   useEffect(() => {
-    displayBottomOfElement(chatboxConversationContainer);
+    scrollToBottomOfElement(chatboxConversationContainer);
   }, [chat.conversation]);
 
   const chatboxConversationContainer = useRef(null);

--- a/src/utils/classrooms.tsx
+++ b/src/utils/classrooms.tsx
@@ -27,18 +27,10 @@ export function filterWords(words: string) {
   }
 }
 
-export function displayBottomOfElement(refObject) {
-  // used to display the bottom of a chatbox whenever a new message comes in
-  // used on pages with multiple chatboxes, i.e. teachers page
+export function scrollToBottomOfElement(refObject) {
+  /* used to ensure the user always sees the latest chat messages by automatically scrolling to
+     the bottom of a chatbox whenever a new message is received */
   refObject.current.scrollTop = refObject.current.scrollHeight;
-}
-
-export function scrollSlowlyIntoView(refObject) {
-  // used to display the bottom of a chatbox whenever a new message comes in
-  // used on pages with only one chatbox, i.e. students page
-  // do not use this function on pages with multiple chatboxes as then it'd scroll other chatboxes into view whenever a new message arrives
-  if (refObject.current)
-    refObject.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
 export interface ClassroomProps {


### PR DESCRIPTION
Previously, the chats on teacher's page lacked smooth scrolling. And previously the chats on students page on mobile would sometime scroll too far to below the chatbox.

This pr fixes both issues.