### PR TITLE
Lengthened chat to fix mobile UI bug

### DIFF
--- a/src/components/pages/StudentsPage/Chatbox.css.tsx
+++ b/src/components/pages/StudentsPage/Chatbox.css.tsx
@@ -12,9 +12,9 @@ const chatboxContainer = css`
 const chatboxTop = css`
   background: #f8e5e0;
   border-radius: 10px 10px 0 0;
-  min-height: 260px;
+  min-height: 320px;
   padding: 10px 10px 0 10px;
-  max-height: 260px;
+  max-height: 320px;
   overflow-y: overlay;
   scroll-behavior: smooth;
 `;

--- a/src/components/pages/StudentsPage/index.tsx
+++ b/src/components/pages/StudentsPage/index.tsx
@@ -1,12 +1,14 @@
 import { Box, Typography } from '@mui/material';
 import { useContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import Image from 'next/image';
 
 import { ClassroomProps, currentTime } from '@utils/classrooms';
 import { SocketContext } from '@contexts/SocketContext';
 import { UserContext } from '@contexts/UserContext';
 import Chatbox from './Chatbox';
 import WelcomeMessage from './WelcomeMessage';
+import RoleplayMasks from '../../../../public/roleplayMasks.png';
 
 export default function StudentsPage({ classroomName }: ClassroomProps) {
   const socket = useContext(SocketContext);
@@ -64,6 +66,21 @@ export default function StudentsPage({ classroomName }: ClassroomProps) {
 
   return (
     <main>
+      <Typography variant='h4' textAlign='center' my={1}>
+        Frempco
+      </Typography>
+      <Box m={1} display='flex' justifyContent='center'>
+        <Image
+          src={RoleplayMasks}
+          alt='Roleplaying masks'
+          priority={true}
+          width={80}
+          style={{
+            maxWidth: '100%',
+            height: 'auto',
+          }}
+        />
+      </Box>
       <Typography
         variant='h4'
         sx={{ color: 'black', mb: 4, textAlign: 'center' }}

--- a/src/components/pages/TeachersPage/Chatbox.css.tsx
+++ b/src/components/pages/TeachersPage/Chatbox.css.tsx
@@ -7,9 +7,9 @@ const chatboxContainer = css`
 const chatboxTop = css`
   background: #f8e5e0;
   border-radius: 10px 10px 0 0;
-  min-height: 260px;
+  min-height: 280px;
   padding: 10px;
-  max-height: 260px;
+  max-height: 280px;
   overflow-y: overlay;
   scroll-behavior: smooth;
 `;


### PR DESCRIPTION
On mobile phones, since student chatbox did not take up the whole vertical screen, there'd be lots of empty space at the bottom.   The problem with the empty space is that the autofocus on the send message input caused much of the screen to initially show much empty blank space upon starting the student chat.
To address this issue, I removed much empty space by 1) Adding a heading with a picture of the "roleplaying masks".  2) Increasing the length of the chatbox.