### PR TITLE
Scrolls when chat is expanded on teachers page

### DIFF
--- a/src/components/pages/TeachersPage/ReadOnlyChatbox.tsx
+++ b/src/components/pages/TeachersPage/ReadOnlyChatbox.tsx
@@ -46,12 +46,13 @@ export default function ReadOnlyChatbox({
   useEffect(() => {
     if (isExpanded) {
       // Scroll the buttons container into view when the chatbox's expand animation finishes
+      const expansionAnimationInMilliseconds = 300;
       setTimeout(() => {
         buttonsContainerRef.current.scrollIntoView({
           behavior: 'smooth',
           block: 'end',
         });
-      }, 300);
+      }, expansionAnimationInMilliseconds);
     }
   }, [isExpanded]);
 


### PR DESCRIPTION
Resolves #105 
When a chatbox is expanded on the Teachers Page, it immediately does the following two scrolls: 
1) Scrolls the chat conversation to the latest message
2) Scrolls into view the buttons container at the bottom of the chatbox