### PR TITLE
ISS-117: Prevent saving empty character list

### DIFF
--- a/src/components/pages/TeachersPage/SetCharacterList.tsx
+++ b/src/components/pages/TeachersPage/SetCharacterList.tsx
@@ -18,20 +18,28 @@ export default function SetCharacterList({
   const [open, setOpen] = useState(false);
   const characterListTextArea = useRef<HTMLTextAreaElement>();
 
+  const [error, setError] = useState<string | null>(null);
+
   const setCharacterList = () => {
     const characters = characterListTextArea.current.value.split('\n');
     const trimmedCharacters = characters
       .map((ch) => ch.trim())
       .filter((ch) => ch);
 
+    if (trimmedCharacters.length === 0) {
+      setError('Error: Please enter at least one character name.');
+      return;
+    }
+
     setCharacters(trimmedCharacters);
     setOpen(false);
+    setError(null);
   };
 
   return (
     <>
       <Typography fontFamily='Lora' fontSize='20px' sx={{ mb: 1 }}>
-        Characters: {characters?.length > 0 && characters.join(', ')}
+        Characters: {characters.join(', ')}
       </Typography>
       <Button
         variant='contained'
@@ -53,6 +61,12 @@ export default function SetCharacterList({
           defaultValue={characters.join('\n')}
           inputRef={characterListTextArea}
         />
+
+        {error && (
+          <Typography color='error' sx={{ mt: 2, textAlign: 'center' }}>
+            {error}
+          </Typography>
+        )}
 
         <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: 2 }}>
           <Button variant='contained' size='large' onClick={setCharacterList}>


### PR DESCRIPTION
Resolves #117 

### Changes
- Adds local error state in SetCharacterList
- Blocks save when the trimmed list is empty
- Displays a red error message above the Save button

### Behavior
- Empty list → error shown, modal stays open
- At least 1 character → saves successfully

### Follow-up
Error message clears on successful save; we could optionally clear it as soon as the user enters at least one character name.