### PR TITLE
Uses Material Symbols Icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@vercel/analytics": "^0.1.6",
         "bad-words": "^3.0.4",
         "lodash-es": "^4.17.21",
+        "material-symbols": "^0.40.2",
         "next": "^14.2.3",
         "prettier": "^2.4.1",
         "react": "^18.3.1",
@@ -3661,6 +3662,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/material-symbols": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/material-symbols/-/material-symbols-0.40.2.tgz",
+      "integrity": "sha512-QUJF1HztvcpP8pXHPPNESK05Thq/Zy8ub17T2xBDf4+gqx4KBs353lKHuVzE/eCYOtiB9JBlFOU7cjAI6vVMTQ=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@vercel/analytics": "^0.1.6",
     "bad-words": "^3.0.4",
     "lodash-es": "^4.17.21",
+    "material-symbols": "^0.40.2",
     "next": "^14.2.3",
     "prettier": "^2.4.1",
     "react": "^18.3.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import { CssBaseline } from '@mui/material';
 import { CacheProvider, EmotionCache } from '@emotion/react';
 import { Analytics as VercelAnalytics } from '@vercel/analytics/react';
+import 'material-symbols';
 
 import theme from '@theme/muiTheme';
 import { createEmotionCache } from '@config/emotion';

--- a/src/components/pages/HomePage/StudentsButton.tsx
+++ b/src/components/pages/HomePage/StudentsButton.tsx
@@ -1,10 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import { Button, Typography } from '@mui/material';
-import {
-  Lightbulb as LightbulbIcon,
-  PlayArrowOutlined as PlayArrowOutlinedIcon,
-} from '@mui/icons-material';
+import { Button, Icon, Typography } from '@mui/material';
 import { useState, useRef, useCallback } from 'react';
 import { throttle } from 'lodash-es';
 
@@ -36,7 +32,7 @@ export default function StudentsButton({ visitStudentsPage }) {
       <Button
         variant='contained'
         color='primary'
-        startIcon={<PlayArrowOutlinedIcon />}
+        startIcon={<Icon sx={{ fontSize: 24 }}>play_arrow</Icon>}
         onClick={() => setOpen(true)}
       >
         Join a Game

--- a/src/theme/muiTheme.ts
+++ b/src/theme/muiTheme.ts
@@ -1,6 +1,6 @@
 import { createTheme } from '@mui/material/styles';
 import '@mui/material/styles';
-import { palette, typography, MuiButton } from './themeVariables';
+import { palette, typography, MuiButton, MuiIcon } from './themeVariables';
 
 declare module '@mui/material/styles' {
   interface Palette {
@@ -28,6 +28,7 @@ const theme = createTheme({
   typography,
   components: {
     MuiButton,
+    MuiIcon,
   },
 });
 

--- a/src/theme/themeVariables.ts
+++ b/src/theme/themeVariables.ts
@@ -149,3 +149,10 @@ export const MuiButton: Components['MuiButton'] = {
     },
   ],
 };
+
+export const MuiIcon = {
+  defaultProps: {
+    // Replaces the `material-icons` default value.
+    baseClassName: 'material-symbols-outlined',
+  },
+};


### PR DESCRIPTION
Resolves #142 

@karlrez fyi that after this merges you'll need to do npm install. This PR installs the Material Symbols icons library. Also, going forward, we should use the icons like I did in this PR from Google Material Symbols as thats whats in our Figma designs.  (This is NOT Material UI icons.)

<img width="610" height="376" alt="image" src="https://github.com/user-attachments/assets/3823fff4-dc1f-45a4-abe3-dd572fad5ccb" />
