### PR TITLE
toggle hiding/showing navbar buttons on scroll

### DIFF
--- a/src/components/pages/HomePage/Header.tsx
+++ b/src/components/pages/HomePage/Header.tsx
@@ -39,8 +39,6 @@ export default function Header({
     return () => window.removeEventListener('scroll', handleScroll);
   }, [headerRef, scrollTrackRef, setIsScrollTrackVisible]);
 
-  const showStudentsBtn = !isXs || (isXs && !isScrollTrackVisible);
-
   return (
     <Box
       ref={headerRef}
@@ -76,10 +74,12 @@ export default function Header({
         gap={1}
         height='52px' // Prevent layout shift when buttons appear/disappear
       >
-        {showStudentsBtn && (
+        {!isScrollTrackVisible && (
           <StudentsButton visitStudentsPage={visitStudentsPage} />
         )}
-        {!isXs && <TeachersButton visitTeachersPage={visitTeachersPage} />}
+        {!isXs && !isScrollTrackVisible && (
+          <TeachersButton visitTeachersPage={visitTeachersPage} />
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
Resolves #154 

Update to show the "Join a Game" and "Start a Game" buttons in the navbar once they are scrolled past.


https://github.com/user-attachments/assets/f92613ad-7c89-4870-bc14-78948533a7f8

