### PR TITLE
Homepage header ux design for desktop

### DIFF
--- a/src/components/pages/HomePage/Header.tsx
+++ b/src/components/pages/HomePage/Header.tsx
@@ -70,11 +70,11 @@ export default function Header({
       bgcolor='neutrals.white'
       sx={{ padding: { xs: '24px 40px', md: '12px 80px' } }}
     >
-      <Box display='flex' gap={1} alignItems='flex-end'>
+      <Box display='flex' gap={2} alignItems='flex-end'>
         <img
           src='/frempco-logo-icon.svg'
           alt='Frempco logo icon'
-          style={{ height: 36, width: 'auto', marginRight: 8 }}
+          style={{ height: 36, width: 'auto' }}
         />
         {!isMobile && (
           <img


### PR DESCRIPTION
Resolves desktop version of #158.

Mobile version to be done in a future PR.

screenshot:
<img width="1901" height="798" alt="image" src="https://github.com/user-attachments/assets/40292558-511b-443e-b5af-eb3b3aae5bc8" />
