### PR TITLE
Improves homepage header UX design for Mobile

### DIFF
--- a/src/components/pages/HomePage/Header.tsx
+++ b/src/components/pages/HomePage/Header.tsx
@@ -56,7 +56,9 @@ export default function Header({
     };
   }, [gameButtonsRef, headerRef]);
 
-  const hasSpaceForLogoText = !isMobile || !shouldShowHeaderButtons;
+  // There is room for the logo text on desktop. And also on mobile when the
+  // buttons are hidden.
+  const showLogoText = !isMobile || !shouldShowHeaderButtons;
 
   return (
     <Box
@@ -78,7 +80,7 @@ export default function Header({
           alt='Frempco logo icon'
           style={{ height: isMobile ? 50 : 36, width: 'auto' }}
         />
-        {hasSpaceForLogoText && (
+        {showLogoText && (
           <img
             src='/frempco-logo-text.svg'
             alt='Frempco logo text'


### PR DESCRIPTION
Part of #158 

Improves the Header layout of both Desktop and Mobile.

The transition of these buttons popping in and out is abrupt. A future PR will make the transition a smoother animation.

**Mobile image 1:**
<img width="363" height="392" alt="image" src="https://github.com/user-attachments/assets/99bdeb7a-f069-4c33-bee1-2a86647ec674" />


**Mobile image 2:**
<img width="364" height="295" alt="image" src="https://github.com/user-attachments/assets/255134ee-46af-4581-b2a1-64091b7cc485" />


**Desktop:**
<img width="1907" height="402" alt="image" src="https://github.com/user-attachments/assets/39afac87-1bc3-43de-a7f0-ea445ea6d024" />

 