### PR TITLE
Fixes bug where header wasn't sticky on Samsung S8 Browser

### DIFF
--- a/src/components/pages/HomePage/Header.tsx
+++ b/src/components/pages/HomePage/Header.tsx
@@ -43,7 +43,7 @@ export default function Header({
       top={0}
       zIndex={1000}
       bgcolor='neutrals.white'
-      sx={{ padding: { xs: '12px 16px', md: '12px 80px' } }}
+      sx={{ padding: { xs: '10px 16px', md: '12px 80px' } }}
     >
       <Box display='flex' gap={2} alignItems='flex-end'>
         <img
@@ -61,7 +61,7 @@ export default function Header({
         gap={isMobile ? 0 : 1}
         height='52px' // Prevent layout shift when buttons appear/disappear
         alignItems='center'
-        sx={getHeaderButtonsSx(shouldShowHeaderButtons)}
+        sx={getHeaderButtonsSx(shouldShowHeaderButtons, isMobile)}
       >
         <StudentsButton visitStudentsPage={visitStudentsPage} />
         {!isMobile && <TeachersButton visitTeachersPage={visitTeachersPage} />}
@@ -80,11 +80,12 @@ function LogoText({ showLogoText, transition }: LogoTextProps) {
     <Box
       sx={{
         display: 'flex',
-        maxWidth: showLogoText ? '220px' : '0px',
+        width: showLogoText ? 'auto' : '0px',
+        overflow: 'hidden',
         opacity: showLogoText ? 1 : 0,
         transform: showLogoText ? 'scale(1)' : 'scale(0.5)',
-        transition: `max-width ${transition}, opacity ${transition}, transform ${transition}, margin ${transition}`,
-        willChange: 'max-width, opacity, transform, margin',
+        transition: `width ${transition}, opacity ${transition}, transform ${transition}, margin ${transition}`,
+        willChange: 'width, opacity, transform, margin',
       }}
     >
       <img
@@ -98,13 +99,20 @@ function LogoText({ showLogoText, transition }: LogoTextProps) {
 
 const HEADER_ANIMATION_TRANSITION = '220ms cubic-bezier(0.4, 0, 0.2, 1)';
 
-function getHeaderButtonsSx(shouldShowHeaderButtons: boolean) {
+function getHeaderButtonsSx(
+  shouldShowHeaderButtons: boolean,
+  isMobile: boolean,
+) {
   return {
+    // retains the space for desktop layout; removes the space on mobile when buttons are hidden
     opacity: shouldShowHeaderButtons ? 1 : 0,
+    width: isMobile && !shouldShowHeaderButtons ? '0px' : 'auto',
+    overflow: 'hidden',
+    visibility: isMobile || shouldShowHeaderButtons ? 'visible' : 'hidden',
+
     transform: shouldShowHeaderButtons ? 'translateY(0)' : 'translateY(-6px)',
-    visibility: shouldShowHeaderButtons ? 'visible' : 'hidden',
     pointerEvents: shouldShowHeaderButtons ? 'auto' : 'none',
-    transition: `opacity ${HEADER_ANIMATION_TRANSITION}, transform ${HEADER_ANIMATION_TRANSITION}, visibility ${HEADER_ANIMATION_TRANSITION}`,
-    willChange: 'opacity, transform',
+    transition: `width ${HEADER_ANIMATION_TRANSITION}, height ${HEADER_ANIMATION_TRANSITION}, opacity ${HEADER_ANIMATION_TRANSITION}, transform ${HEADER_ANIMATION_TRANSITION}`,
+    willChange: 'width, height, opacity, transform',
   };
 }


### PR DESCRIPTION
Part of #158 

This fixes the bug on Samsung S8 browsers in which the header wasn't sticky.  The cause was that the header layout was wider than 100% of the browser screen.  By fixing the css value, the header now stays at 100% of the browser width.