### PR TITLE
Add placeholders for login flow components

### DIFF
--- a/src/components/pages/StudentsPage/Header.tsx
+++ b/src/components/pages/StudentsPage/Header.tsx
@@ -1,0 +1,5 @@
+/** @jsxImportSource @emotion/react */
+
+export default function Header(): JSX.Element {
+  return <div>Header placeholder</div>;
+}

--- a/src/components/pages/StudentsPage/LoginFlow.tsx
+++ b/src/components/pages/StudentsPage/LoginFlow.tsx
@@ -1,0 +1,5 @@
+/** @jsxImportSource @emotion/react */
+
+export default function LoginFlow(): JSX.Element {
+  return <div>Login Flow placeholder</div>;
+}

--- a/src/components/pages/StudentsPage/index.tsx
+++ b/src/components/pages/StudentsPage/index.tsx
@@ -3,11 +3,13 @@ import { useContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 
 import { ClassroomProps, currentTime, PAIRED, SOLO } from '@utils/classrooms';
+import featureFlags from '@config/featureFlags';
 import { SocketContext } from '@contexts/SocketContext';
 import { UserContext } from '@contexts/UserContext';
 import Chatbox from './Chatbox';
 import WelcomeMessage from './WelcomeMessage';
-import featureFlags from '@config/featureFlags';
+import Header from './Header';
+import LoginFlow from './LoginFlow';
 
 export type ChatMessage = ['you' | 'peer', string];
 
@@ -125,7 +127,12 @@ export default function StudentsPage({ classroomName }: ClassroomProps) {
   }, [router.events, socket]);
 
   if (featureFlags.newLoginFlowForStudents.enabled) {
-    return <main>New Student login flow</main>;
+    return (
+      <main>
+        <Header />
+        <LoginFlow />
+      </main>
+    );
   }
 
   return (


### PR DESCRIPTION
Part of #184 

Now that these placeholder components exist, the next PRs will fill them in. 

Screenshot:
<img width="585" height="298" alt="image" src="https://github.com/user-attachments/assets/2f852e39-b76e-42ef-8a3c-4736e4e80442" />
