### PR TITLE
Allows student to reload the page and create a new dev test user

### DIFF
--- a/src/components/pages/HomePage/index.tsx
+++ b/src/components/pages/HomePage/index.tsx
@@ -17,6 +17,8 @@ import Hero from './Hero';
 import ProductBenefits from './ProductBenefits';
 import { DEV_TEST_USER_QUERY_PARAM } from '@utils/classrooms';
 
+const DEV_TEST_USER_SESSION_FLAG = 'wasDevTestUserSet';
+
 export default function HomePage() {
   const router = useRouter();
   const socket = useContext(SocketContext);
@@ -29,6 +31,11 @@ export default function HomePage() {
     const studentUrl = isDevTestUser
       ? `/student?${DEV_TEST_USER_QUERY_PARAM}=true`
       : '/student';
+
+    // Deletes any prior dev test user session flags. A new one gets saved into
+    // session storage when visiting the students page.
+    if (isDevTestUser) sessionStorage.removeItem(DEV_TEST_USER_SESSION_FLAG);
+
     router.push(studentUrl);
   }
 

--- a/src/components/shared/Layout.tsx
+++ b/src/components/shared/Layout.tsx
@@ -1,30 +1,9 @@
-import { Box, Typography } from '@mui/material';
-import Link from '@components/shared/Link';
+import { Box } from '@mui/material';
 
 interface LayoutProps {
   children: React.ReactNode;
 }
 
 export default function Layout({ children }: LayoutProps) {
-  return (
-    <Box sx={{ minHeight: '100vh' }}>
-      <DevHomeLinkShortcut />
-      {children}
-    </Box>
-  );
-}
-
-function DevHomeLinkShortcut() {
-  return (
-    process.env.NEXT_PUBLIC_NODE_ENV === 'development' && (
-      <>
-        <Typography variant='h5' sx={{ color: 'gray' }}>
-          This link shortcut only appears in the development environment:
-        </Typography>
-        <Typography variant='h4' sx={{ ml: 10, pt: 1, pb: 2 }}>
-          <Link href='/'>Home</Link>
-        </Typography>
-      </>
-    )
-  );
+  return <Box sx={{ minHeight: '100vh' }}>{children}</Box>;
 }


### PR DESCRIPTION
Part of #197 

Allows dev test user to visit the homepage and reload the page and then signin again as a dev test user. This speeds up the development of the students page as it makes it easier to create dev test users for students page.