### PR TITLE
Iss 249 dont show green arrows if under 3 students

### DIFF
--- a/src/components/pages/TeachersPage/UnpairedStudentsAccordion/UnpairedStudentItem.tsx
+++ b/src/components/pages/TeachersPage/UnpairedStudentsAccordion/UnpairedStudentItem.tsx
@@ -1,5 +1,4 @@
-/** @jsxImportSource @emotion/react */
-
+import { Dispatch, SetStateAction } from 'react';
 import {
   ArrowUpward as ArrowUpwardIcon,
   ArrowDownward as ArrowDownwardIcon,
@@ -7,7 +6,19 @@ import {
   PersonOutline as PersonOutlineIcon,
 } from '@mui/icons-material';
 import { Button, Box, IconButton, Typography } from '@mui/material';
+import { Socket } from 'socket.io-client';
 import { getRandom, swap, SOLO } from '@utils/classrooms';
+import { SoloChat, Student, StudentChat } from '../types';
+
+interface UnpairedStudentItemProps {
+  i: number;
+  student: Student;
+  socket: Socket;
+  setUnpairedStudents: Dispatch<SetStateAction<Student[]>>;
+  characters: string[];
+  setStudentChats: Dispatch<SetStateAction<(StudentChat | SoloChat)[]>>;
+  totalUnpairedStudents: number;
+}
 
 export default function UnpairedStudentItem({
   i,
@@ -17,7 +28,7 @@ export default function UnpairedStudentItem({
   characters,
   setStudentChats,
   totalUnpairedStudents,
-}) {
+}: UnpairedStudentItemProps) {
   function swapStudents(student1Index: number, student2Index: number) {
     setUnpairedStudents((unpairedStudents) => {
       const unpaired = [...unpairedStudents];
@@ -30,7 +41,7 @@ export default function UnpairedStudentItem({
     });
   }
 
-  function removeStudent(student) {
+  function removeStudent(student: Student) {
     const confirmation = confirm(
       `Are you sure you want to remove ${student.realName}?`,
     );

--- a/src/components/pages/TeachersPage/UnpairedStudentsAccordion/UnpairedStudentItem.tsx
+++ b/src/components/pages/TeachersPage/UnpairedStudentsAccordion/UnpairedStudentItem.tsx
@@ -16,6 +16,7 @@ export default function UnpairedStudentItem({
   setUnpairedStudents,
   characters,
   setStudentChats,
+  totalUnpairedStudents,
 }) {
   function swapStudents(student1Index: number, student2Index: number) {
     setUnpairedStudents((unpairedStudents) => {
@@ -96,30 +97,34 @@ export default function UnpairedStudentItem({
           {student.realName}
         </Typography>
 
-        <IconButton
-          aria-label='move up'
-          size='small'
-          sx={{
-            marginLeft: 'auto',
-            color: 'green',
-            ':hover': { color: 'white', bgcolor: 'green' },
-          }}
-          onClick={() => swapStudents(i, i - 1)}
-        >
-          <ArrowUpwardIcon fontSize='small' />
-        </IconButton>
+        {totalUnpairedStudents > 2 && (
+          <>
+            <IconButton
+              aria-label='move up'
+              size='small'
+              sx={{
+                marginLeft: 'auto',
+                color: 'green',
+                ':hover': { color: 'white', bgcolor: 'green' },
+              }}
+              onClick={() => swapStudents(i, i - 1)}
+            >
+              <ArrowUpwardIcon fontSize='small' />
+            </IconButton>
 
-        <IconButton
-          aria-label='move down'
-          size='small'
-          sx={{
-            color: 'green',
-            ':hover': { color: 'white', bgcolor: 'green' },
-          }}
-          onClick={() => swapStudents(i, i + 1)}
-        >
-          <ArrowDownwardIcon fontSize='small' />
-        </IconButton>
+            <IconButton
+              aria-label='move down'
+              size='small'
+              sx={{
+                color: 'green',
+                ':hover': { color: 'white', bgcolor: 'green' },
+              }}
+              onClick={() => swapStudents(i, i + 1)}
+            >
+              <ArrowDownwardIcon fontSize='small' />
+            </IconButton>
+          </>
+        )}
       </Box>
     </>
   );

--- a/src/components/pages/TeachersPage/UnpairedStudentsAccordion/UnpairedStudentItem.tsx
+++ b/src/components/pages/TeachersPage/UnpairedStudentsAccordion/UnpairedStudentItem.tsx
@@ -115,8 +115,8 @@ export default function UnpairedStudentItem({
               size='small'
               sx={{
                 marginLeft: 'auto',
-                color: 'green',
-                ':hover': { color: 'white', bgcolor: 'green' },
+                color: 'secondary.600',
+                ':hover': { color: 'neutrals.white', bgcolor: 'secondary.600' },
               }}
               onClick={() => swapStudents(i, i - 1)}
             >
@@ -127,8 +127,8 @@ export default function UnpairedStudentItem({
               aria-label='move down'
               size='small'
               sx={{
-                color: 'green',
-                ':hover': { color: 'white', bgcolor: 'green' },
+                color: 'secondary.600',
+                ':hover': { color: 'neutrals.white', bgcolor: 'secondary.600' },
               }}
               onClick={() => swapStudents(i, i + 1)}
             >

--- a/src/components/pages/TeachersPage/UnpairedStudentsAccordion/UnpairedStudentsList.tsx
+++ b/src/components/pages/TeachersPage/UnpairedStudentsAccordion/UnpairedStudentsList.tsx
@@ -111,6 +111,7 @@ export default function UnpairedStudentsList({
                 setUnpairedStudents={setUnpairedStudents}
                 characters={characters}
                 setStudentChats={setStudentChats}
+                totalUnpairedStudents={unpairedStudents.length}
               />
               {student2 && (
                 <UnpairedStudentItem
@@ -120,6 +121,7 @@ export default function UnpairedStudentsList({
                   setUnpairedStudents={setUnpairedStudents}
                   characters={characters}
                   setStudentChats={setStudentChats}
+                  totalUnpairedStudents={unpairedStudents.length}
                 />
               )}
             </Grid>

--- a/src/components/pages/TeachersPage/UnpairedStudentsAccordion/UnpairedStudentsList.tsx
+++ b/src/components/pages/TeachersPage/UnpairedStudentsAccordion/UnpairedStudentsList.tsx
@@ -1,12 +1,20 @@
-/** @jsxImportSource @emotion/react */
-
-import { useEffect } from 'react';
+import { Dispatch, SetStateAction, useEffect } from 'react';
 import { Box, Button, Grid, Typography } from '@mui/material';
 import { Chat as ChatIcon, Group as GroupIcon } from '@mui/icons-material';
 import { chunk } from 'lodash-es';
+import { Socket } from 'socket.io-client';
 
 import { getRandom } from '@utils/classrooms';
+import { SoloChat, Student, StudentChat } from '../types';
 import UnpairedStudentItem from './UnpairedStudentItem';
+
+interface UnpairedStudentsListProps {
+  socket: Socket;
+  unpairedStudents: Student[];
+  setUnpairedStudents: Dispatch<SetStateAction<Student[]>>;
+  setStudentChats: Dispatch<SetStateAction<(StudentChat | SoloChat)[]>>;
+  characters: string[];
+}
 
 export default function UnpairedStudentsList({
   socket,
@@ -14,7 +22,7 @@ export default function UnpairedStudentsList({
   setUnpairedStudents,
   setStudentChats,
   characters,
-}) {
+}: UnpairedStudentsListProps) {
   useEffect(() => {
     if (socket) {
       socket.on('new student joined', (student) => {


### PR DESCRIPTION
Resolves #249 

- also made the arrows a lighter green to make them less prominent as they're secondary, less important buttons.

Screenshot for many unpaired students:
<img width="756" height="406" alt="image" src="https://github.com/user-attachments/assets/e49483c6-6e7e-460d-bd1f-d482a3db660a" />

Screenshot for 2 unpaired students:
<img width="777" height="360" alt="image" src="https://github.com/user-attachments/assets/76be9d9a-dee1-4ac1-86b2-26d1fc79db3b" />
