### PR TITLE
Added warning message about screen going dark

### DIFF
--- a/src/components/pages/StudentsPage/WelcomeMessage.tsx
+++ b/src/components/pages/StudentsPage/WelcomeMessage.tsx
@@ -1,5 +1,3 @@
-/** @jsxImportSource @emotion/react */
-
 import { useEffect, useRef } from 'react';
 import { Box, Typography } from '@mui/material';
 import Image from 'next/image';
@@ -100,9 +98,17 @@ export default function WelcomeMessage({
           </Typography>
         </>
       ) : (
-        <Typography variant='body1'>
-          Welcome to the game room! Your teacher will pair you soon...
-        </Typography>
+        <>
+          <Typography variant='body1' sx={{ mx: 1 }}>
+            Welcome to the game room! Your teacher will pair you soon...
+          </Typography>
+          {isMobile && (
+            <Typography variant='body2' sx={{ mt: 2, mx: 1 }}>
+              Note: You will be logged out of Frempco if your smartphone screen
+              goes dark.
+            </Typography>
+          )}
+        </>
       )}
     </Box>
   );

--- a/src/components/pages/TeachersPage/index.tsx
+++ b/src/components/pages/TeachersPage/index.tsx
@@ -191,6 +191,10 @@ export default function TeachersPage({ classroomName }: ClassroomProps) {
           <Typography variant='body1' mb={1}>
             {'2)'} Enter Game Pin: <strong>{classroomName}</strong>
           </Typography>
+          <Typography variant='body2' sx={{ mt: 2 }}>
+            Note: Your students on smartphones will be logged out of Frempco if
+            their smartphone screen goes dark.
+          </Typography>
         </Box>
         <SetupClassroomAccordion
           classroomName={classroomName}


### PR DESCRIPTION
Resolves #261 

Students page on Mobile:
<img width="261" height="560" alt="image" src="https://github.com/user-attachments/assets/c895b434-ae09-4cb2-b865-f78e5b3383da" />

Teachers page:
<img width="1052" height="382" alt="image" src="https://github.com/user-attachments/assets/88c1040b-6daa-4320-843c-ba88cf4d064e" />
