### PR TITLE
created initial CompletedChatsAccordion

### DIFF
--- a/src/components/pages/TeachersPage/ActiveGameRoom/CompletedChatsAccordion/index.tsx
+++ b/src/components/pages/TeachersPage/ActiveGameRoom/CompletedChatsAccordion/index.tsx
@@ -1,0 +1,34 @@
+import {
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Typography,
+} from '@mui/material';
+import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
+import { StudentChat, SoloChat } from '../../types';
+
+interface CompletedChatsAccordionProps {
+  studentChats: (StudentChat | SoloChat)[];
+}
+
+const CompletedChatsAccordion =
+  ({}: CompletedChatsAccordionProps): JSX.Element => {
+    return (
+      <Accordion disableGutters sx={{ boxShadow: 'none', mb: 3 }}>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          sx={{ borderRadius: '15px', border: '1px solid black', gap: 2 }}
+        >
+          <Typography variant='h5' fontWeight={400}>
+            Step 4: View Completed Chats
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          {/* Placeholder - Replace with <DisplayOfChats /> */}
+          <div>Completed chats will show here</div>
+        </AccordionDetails>
+      </Accordion>
+    );
+  };
+
+export default CompletedChatsAccordion;

--- a/src/components/pages/TeachersPage/ActiveGameRoom/index.tsx
+++ b/src/components/pages/TeachersPage/ActiveGameRoom/index.tsx
@@ -10,6 +10,7 @@ import Link from '@components/shared/Link';
 import UnpairedStudentsAccordion from './UnpairedStudentsAccordion';
 import SetupClassroomAccordion from './SetupClassroomAccordion';
 import ChatsInProgressAccordion from './ChatsInProgressAccordion';
+import CompletedChatsAccordion from './CompletedChatsAccordion';
 import featureFlags from '@config/featureFlags';
 
 interface ActiveGameRoomProps {
@@ -208,7 +209,7 @@ export default function ActiveGameRoom({
           setUnpairedStudents={setUnpairedStudents}
         />
         {featureFlags.isCompletedChatsSectionLaunched.enabled && (
-          <div>Completed chats section</div>
+          <CompletedChatsAccordion studentChats={[]} />
         )}
       </Box>
     </main>


### PR DESCRIPTION
Resolves #275 

Initial Accordion component for completed chats on Teachers page.
Just renders placeholder string when expanded.

<img width="1469" height="597" alt="image" src="https://github.com/user-attachments/assets/6b33b9d7-c91f-4593-8683-4ae4d9bdc9ed" />
