### PR TITLE
prevent rerenders on the teachers page

### DIFF
--- a/src/components/pages/TeachersPage/InProgressActivity/Chatbox/index.tsx
+++ b/src/components/pages/TeachersPage/InProgressActivity/Chatbox/index.tsx
@@ -1,9 +1,10 @@
 import { Box, Button, Paper } from '@mui/material';
 import {
   Dispatch,
+  memo,
   SetStateAction,
-  useRef,
   useEffect,
+  useRef,
   useState,
 } from 'react';
 import {
@@ -14,16 +15,16 @@ import {
 
 import ChatboxHeader from '@components/shared/ChatboxHeader';
 import { scrollToBottomOfElement, SOLO } from '@utils/activities';
-import { StudentChat, SoloChat } from '../../types';
+import { Student, StudentChat, SoloChat } from '../../types';
 import { useSocketConnection } from '@contexts/SocketContext';
 import Conversation from './Conversation';
 
 interface ChatboxProps {
   chat: StudentChat | SoloChat;
-  setStudentChats: Dispatch<SetStateAction<(StudentChat | SoloChat)[]>>;
+  setStudentChats?: Dispatch<SetStateAction<(StudentChat | SoloChat)[]>>;
 }
 
-export default function Chatbox({ chat, setStudentChats }: ChatboxProps) {
+function Chatbox({ chat, setStudentChats }: ChatboxProps) {
   const { socket } = useSocketConnection();
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -39,7 +40,7 @@ export default function Chatbox({ chat, setStudentChats }: ChatboxProps) {
       // Scroll the buttons container into view when the chatbox's expand animation finishes
       const expansionAnimationInMilliseconds = 300;
       setTimeout(() => {
-        buttonsContainerRef.current.scrollIntoView({
+        buttonsContainerRef.current?.scrollIntoView({
           behavior: 'smooth',
           block: 'end',
         });
@@ -47,7 +48,14 @@ export default function Chatbox({ chat, setStudentChats }: ChatboxProps) {
     }
   }, [isExpanded]);
 
-  function endChat(chatId, chatMode, student1, student2) {
+  function endChat(
+    chatId: string,
+    chatMode: StudentChat['mode'] | SoloChat['mode'],
+    student1: Student,
+    student2?: Student,
+  ) {
+    if (!setStudentChats) return;
+
     const endChatConfirmed = confirm(
       `Are you sure you want to end the ${
         chatMode === SOLO ? 'solo ' : ''
@@ -124,7 +132,7 @@ export default function Chatbox({ chat, setStudentChats }: ChatboxProps) {
         >
           {isExpanded ? 'Collapse' : 'Expand'}
         </Button>
-        {!chat.isCompleted && (
+        {!chat.isCompleted && Boolean(setStudentChats) && (
           <Button
             color='error'
             variant='contained'
@@ -138,3 +146,9 @@ export default function Chatbox({ chat, setStudentChats }: ChatboxProps) {
     </Paper>
   );
 }
+
+export default memo(Chatbox, (prev, next) => {
+  return (
+    prev.chat === next.chat && prev.setStudentChats === next.setStudentChats
+  );
+});

--- a/src/components/pages/TeachersPage/InProgressActivity/ChatsInProgressAccordion/index.tsx
+++ b/src/components/pages/TeachersPage/InProgressActivity/ChatsInProgressAccordion/index.tsx
@@ -22,6 +22,7 @@ const ChatsInProgressAccordion = ({
   setStudentChats,
 }: ChatsInProgressAccordionProps) => {
   const { socket } = useSocketConnection();
+
   const totalStudents = activeStudentChats.length;
   const pairCount = activeStudentChats.filter(
     (chat) => chat.mode === PAIRED,

--- a/src/components/pages/TeachersPage/InProgressActivity/index.tsx
+++ b/src/components/pages/TeachersPage/InProgressActivity/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Box, Typography } from '@mui/material';
 import { Dispatch, SetStateAction } from 'react';
 
@@ -106,7 +106,7 @@ export default function InProgressActivity({
         socket.off('solo mode: student disconnected');
       }
     };
-  }, [socket, studentChats.length]);
+  }, [socket]);
 
   useEffect(() => {
     if (socket) {

--- a/src/components/pages/TeachersPage/InProgressActivity/shared/DisplayOfChats.tsx
+++ b/src/components/pages/TeachersPage/InProgressActivity/shared/DisplayOfChats.tsx
@@ -1,7 +1,7 @@
 import { Grid } from '@mui/material';
 import { Dispatch, SetStateAction } from 'react';
 
-import { Student, StudentChat, SoloChat } from '../../types';
+import { StudentChat, SoloChat } from '../../types';
 import Chatbox from '../Chatbox';
 
 interface DisplayOfChatsProps {
@@ -15,9 +15,9 @@ export default function DisplayOfChats({
 }: DisplayOfChatsProps) {
   return (
     <Grid container spacing={2} mt={2} pb={2}>
-      {studentChats.map((chat, i) => {
+      {studentChats.map((chat) => {
         return (
-          <Grid key={i} item xs={12} md={6} lg={4}>
+          <Grid key={chat.chatId} item xs={12} md={6} lg={4}>
             <Chatbox chat={chat} setStudentChats={setStudentChats} />
           </Grid>
         );


### PR DESCRIPTION
Closes #311 

Prevent uneccesary rerenders of the chatboxes.  when a new chat message comes in, only the chatbox which is for that message will get rerendered. The other chatboxes (both in progress and completed) wont get rerendered.