### PR TITLE
Iss 228 add an end chat button

### DIFF
--- a/src/components/pages/StudentsPage/Chatbox/index.tsx
+++ b/src/components/pages/StudentsPage/Chatbox/index.tsx
@@ -84,6 +84,7 @@ export default function Chatbox({
           { label: "You're:", value: chat.characters.you },
           { label: 'With:', value: chat.characters.peer },
         ]}
+        shouldShowEndChatButton={true}
       />
       <Conversation
         chat={chat}

--- a/src/components/pages/StudentsPage/Chatbox/index.tsx
+++ b/src/components/pages/StudentsPage/Chatbox/index.tsx
@@ -3,7 +3,6 @@ import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import { Socket } from 'socket.io-client';
 
 import ChatboxHeader from '@components/shared/ChatboxHeader';
-import featureFlags from '@config/featureFlags';
 import { scrollToBottomOfElement, PAIRED } from '@utils/activities';
 import { useStudentInActivity } from '../hooks/useStudentInActivity';
 import Conversation from './Conversation';
@@ -97,10 +96,7 @@ export default function Chatbox({
           { label: "You're:", value: chat.characters.you },
           { label: 'With:', value: chat.characters.peer },
         ]}
-        shouldShowEndChatButton={
-          featureFlags.isStudentEndChatButtonLaunched.enabled &&
-          chat.mode === PAIRED
-        }
+        shouldShowEndChatButton={chat.mode === PAIRED}
         onEndChat={handleEndChat}
       />
       <Conversation

--- a/src/components/pages/StudentsPage/Chatbox/index.tsx
+++ b/src/components/pages/StudentsPage/Chatbox/index.tsx
@@ -3,6 +3,7 @@ import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import { Socket } from 'socket.io-client';
 
 import ChatboxHeader from '@components/shared/ChatboxHeader';
+import featureFlags from '@config/featureFlags';
 import { scrollToBottomOfElement, PAIRED } from '@utils/activities';
 import { useStudentInActivity } from '../hooks/useStudentInActivity';
 import Conversation from './Conversation';
@@ -96,7 +97,10 @@ export default function Chatbox({
           { label: "You're:", value: chat.characters.you },
           { label: 'With:', value: chat.characters.peer },
         ]}
-        shouldShowEndChatButton={chat.mode === PAIRED}
+        shouldShowEndChatButton={
+          featureFlags.isStudentEndChatButtonLaunched.enabled &&
+          chat.mode === PAIRED
+        }
         onEndChat={handleEndChat}
       />
       <Conversation

--- a/src/components/pages/StudentsPage/Chatbox/index.tsx
+++ b/src/components/pages/StudentsPage/Chatbox/index.tsx
@@ -3,7 +3,7 @@ import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import { Socket } from 'socket.io-client';
 
 import ChatboxHeader from '@components/shared/ChatboxHeader';
-import { scrollToBottomOfElement } from '@utils/activities';
+import { scrollToBottomOfElement, PAIRED } from '@utils/activities';
 import { useStudentInActivity } from '../hooks/useStudentInActivity';
 import Conversation from './Conversation';
 import SendMessageSection from './SendMessageSection';
@@ -15,6 +15,7 @@ interface ChatboxProps {
   chat: StudentPairedChat | StudentSoloChat;
   setChat: Dispatch<SetStateAction<StudentPairedChat | StudentSoloChat>>;
   chatEndedMsg: null | string;
+  setChatEndedMsg: (message: string | null) => void;
   studentName: string;
   activityPin: string;
   addStudentToActivity: (studentName: string, pin: string) => void;
@@ -27,6 +28,7 @@ export default function Chatbox({
   chat,
   setChat,
   chatEndedMsg,
+  setChatEndedMsg,
   studentName,
   activityPin,
   addStudentToActivity,
@@ -42,6 +44,16 @@ export default function Chatbox({
       ...chat,
       conversation: [...chat.conversation, [sender, message]],
     }));
+  }
+
+  function handleEndChat() {
+    const endChatConfirmed = confirm('Are you sure you want to end this chat?');
+    if (!endChatConfirmed) return;
+
+    socket.emit('student:ended-paired-chat');
+
+    // Update local state immediately
+    setChatEndedMsg('You ended the chat');
   }
 
   useEffect(() => {
@@ -84,7 +96,8 @@ export default function Chatbox({
           { label: "You're:", value: chat.characters.you },
           { label: 'With:', value: chat.characters.peer },
         ]}
-        shouldShowEndChatButton={true}
+        shouldShowEndChatButton={chat.mode === PAIRED}
+        onEndChat={handleEndChat}
       />
       <Conversation
         chat={chat}

--- a/src/components/pages/StudentsPage/hooks/useStudentSocketHandlers.ts
+++ b/src/components/pages/StudentsPage/hooks/useStudentSocketHandlers.ts
@@ -87,12 +87,18 @@ export function useStudentSocketHandlers({
       setChatEndedMsg('Your teacher ended your chat');
     }
 
+    function handleStudentPeerEndedChat() {
+      setStage(STAGE.chatEnded);
+      setChatEndedMsg('Your peer ended the chat');
+    }
+
     socket.on('chat start', handleChatStart);
     socket.on('solo mode: chat started', handleSoloChatStarted);
     socket.on('student:removed-from-activity', handleRemoveStudentFromActivity);
     socket.on('peer left chat', handlePeerLeftChat);
     socket.on('teacher ended chat', handleTeacherEndedChat);
     socket.on('solo mode: teacher ended chat', handleSoloModeTeacherEndedChat);
+    socket.on('student:student-peer-ended-chat', handleStudentPeerEndedChat);
 
     return () => {
       socket.off('chat start', handleChatStart);
@@ -107,6 +113,7 @@ export function useStudentSocketHandlers({
         'solo mode: teacher ended chat',
         handleSoloModeTeacherEndedChat,
       );
+      socket.off('student:student-peer-ended-chat', handleStudentPeerEndedChat);
     };
   }, [setChat, setChatEndedMsg, setStage, socket]);
 }

--- a/src/components/pages/StudentsPage/index.tsx
+++ b/src/components/pages/StudentsPage/index.tsx
@@ -88,6 +88,7 @@ export default function StudentsPage(): JSX.Element {
         chat={chat}
         setChat={setChat}
         chatEndedMsg={chatEndedMsg}
+        setChatEndedMsg={setChatEndedMsg}
         studentName={studentName}
         activityPin={pin}
         addStudentToActivity={addStudentToActivity}

--- a/src/components/pages/TeachersPage/InProgressActivity/Chatbox/index.tsx
+++ b/src/components/pages/TeachersPage/InProgressActivity/Chatbox/index.tsx
@@ -106,7 +106,10 @@ function Chatbox({ chat, setStudentChats }: ChatboxProps) {
         overflow: 'hidden',
       }}
     >
-      <ChatboxHeader headerRows={headerRows} />
+      <ChatboxHeader
+        headerRows={headerRows}
+        shouldShowEndChatButton={false}
+      />
 
       <Conversation
         containerRef={chatboxConversationContainer}

--- a/src/components/pages/TeachersPage/InProgressActivity/index.tsx
+++ b/src/components/pages/TeachersPage/InProgressActivity/index.tsx
@@ -54,6 +54,14 @@ export default function InProgressActivity({
     return { activeChats, completedChats };
   }, [studentChats]);
 
+  function markChatAsCompleted({ chatId }: { chatId: string }) {
+    setStudentChats((chats) =>
+      chats.map((chat) =>
+        chat.chatId === chatId ? { ...chat, isCompleted: true } : chat,
+      ),
+    );
+  }
+
   useEffect(() => {
     // Check if the teacher is still connected to the activity every 10 seconds.
     const connectionCheckInterval = setInterval(async () => {
@@ -110,13 +118,8 @@ export default function InProgressActivity({
 
   useEffect(() => {
     if (socket) {
-      socket.on('chat ended - two students', ({ chatId }) => {
-        setStudentChats((chats) =>
-          chats.map((chat) =>
-            chat.chatId === chatId ? { ...chat, isCompleted: true } : chat,
-          ),
-        );
-      });
+      socket.on('chat ended - two students', markChatAsCompleted);
+      socket.on('teacher:student-ended-chat', markChatAsCompleted);
 
       socket.on(
         'teacher listens to student message',
@@ -161,7 +164,8 @@ export default function InProgressActivity({
     router.events.on('routeChangeStart', handleRouteChange);
 
     return () => {
-      socket.off('chat ended - two students');
+      socket.off('chat ended - two students', markChatAsCompleted);
+      socket.off('teacher:student-ended-chat', markChatAsCompleted);
       socket.off('teacher listens to student message');
       socket.off('solo mode: teacher listens to new message');
       router.events.off('routeChangeStart', handleRouteChange);

--- a/src/components/shared/ChatboxHeader.tsx
+++ b/src/components/shared/ChatboxHeader.tsx
@@ -1,15 +1,18 @@
-import { Box, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
 
 interface HeaderRow {
   label: string;
   value: string;
 }
+
 interface ChatboxHeaderProps {
   headerRows: HeaderRow[];
+  shouldShowEndChatButton: boolean;
 }
 
 export default function ChatboxHeader({
   headerRows,
+  shouldShowEndChatButton,
 }: ChatboxHeaderProps): JSX.Element {
   return (
     <Box
@@ -20,9 +23,32 @@ export default function ChatboxHeader({
         px: '16px',
       }}
     >
-      {headerRows.map(({ label, value }) => (
-        <RowForHeader key={label} label={label} value={value} />
-      ))}
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+        <Box>
+          {headerRows.map(({ label, value }) => (
+            <RowForHeader key={label} label={label} value={value} />
+          ))}
+        </Box>
+        {shouldShowEndChatButton && (
+          <Button
+            variant='contained'
+            disableElevation
+            sx={{
+              alignSelf: 'center',
+              minWidth: 'auto',
+              px: 1.75,
+              py: 0.75,
+              backgroundColor: 'rgba(255, 255, 255, 0.24)',
+              color: 'neutrals.white',
+              '&:hover': {
+                backgroundColor: 'rgba(255, 255, 255, 0.30)',
+              },
+            }}
+          >
+            End
+          </Button>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/src/components/shared/ChatboxHeader.tsx
+++ b/src/components/shared/ChatboxHeader.tsx
@@ -8,11 +8,13 @@ interface HeaderRow {
 interface ChatboxHeaderProps {
   headerRows: HeaderRow[];
   shouldShowEndChatButton: boolean;
+  onEndChat?: () => void;
 }
 
 export default function ChatboxHeader({
   headerRows,
   shouldShowEndChatButton,
+  onEndChat,
 }: ChatboxHeaderProps): JSX.Element {
   return (
     <Box
@@ -33,6 +35,7 @@ export default function ChatboxHeader({
           <Button
             variant='contained'
             disableElevation
+            onClick={onEndChat}
             sx={{
               alignSelf: 'center',
               minWidth: 'auto',

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -5,6 +5,16 @@ interface FeatureFlag {
   description?: string;
 }
 
-const featureFlags: Record<string, FeatureFlag> = {};
+interface FeatureFlags {
+  isStudentEndChatButtonLaunched: FeatureFlag;
+}
+
+const featureFlags: FeatureFlags = {
+  isStudentEndChatButtonLaunched: {
+    enabled: false,
+    description:
+      'Shows the student end-chat button on Students page and enables associated behavior.',
+  },
+};
 
 export default featureFlags;

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -5,16 +5,8 @@ interface FeatureFlag {
   description?: string;
 }
 
-interface FeatureFlags {
-  isStudentEndChatButtonLaunched: FeatureFlag;
-}
+interface FeatureFlags {}
 
-const featureFlags: FeatureFlags = {
-  isStudentEndChatButtonLaunched: {
-    enabled: false,
-    description:
-      'Shows the student end-chat button on Students page and enables associated behavior.',
-  },
-};
+const featureFlags: FeatureFlags = {};
 
 export default featureFlags;


### PR DESCRIPTION
Part of #228 
Backend PR: https://github.com/mssiegel/Frempco-web-server/pull/33
Adds end chat button on students page for paired chats only.
<img width="744" height="653" alt="image" src="https://github.com/user-attachments/assets/ee47ed26-b087-4d3e-8596-b72b3434ac70" />
