### PR TITLE
Iss 323 student chatbox header shows real names

### DIFF
--- a/src/components/pages/StudentsPage/Chatbox/index.tsx
+++ b/src/components/pages/StudentsPage/Chatbox/index.tsx
@@ -44,6 +44,10 @@ export default function Chatbox({
   const [isEndChatModalOpen, setIsEndChatModalOpen] = useState(false);
   const isConnected = useStudentInActivity(activityPin, sessionId);
   const hasChatEnded = !isConnected || Boolean(chatEndedMsg);
+  const peerRealName =
+    chat.mode === PAIRED && chat.shouldRevealPeerRealName
+      ? chat.peerRealName?.trim()
+      : undefined;
 
   function addChatMessage(sender, message: string) {
     setChat((chat) => ({
@@ -100,7 +104,11 @@ export default function Chatbox({
       <ChatboxHeader
         headerRows={[
           { label: "You're:", value: chat.characters.you },
-          { label: 'With:', value: chat.characters.peer },
+          {
+            label: 'With:',
+            value: chat.characters.peer,
+            secondaryValue: peerRealName,
+          },
         ]}
         shouldShowEndChatButton={shouldShowEndChatButton}
         onEndChat={() => setIsEndChatModalOpen(true)}

--- a/src/components/pages/StudentsPage/types.ts
+++ b/src/components/pages/StudentsPage/types.ts
@@ -10,6 +10,8 @@ export interface StudentPairedChat {
     you: string;
     peer: string;
   };
+  peerRealName?: string;
+  shouldRevealPeerRealName?: boolean;
   conversation: ChatMessage[];
 }
 

--- a/src/components/shared/ChatboxHeader.tsx
+++ b/src/components/shared/ChatboxHeader.tsx
@@ -3,6 +3,7 @@ import { Box, Button, Typography } from '@mui/material';
 interface HeaderRow {
   label: string;
   value: string;
+  secondaryValue?: string;
 }
 
 interface ChatboxHeaderProps {
@@ -26,9 +27,14 @@ export default function ChatboxHeader({
       }}
     >
       <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
-        <Box>
-          {headerRows.map(({ label, value }) => (
-            <RowForHeader key={label} label={label} value={value} />
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          {headerRows.map(({ label, value, secondaryValue }) => (
+            <RowForHeader
+              key={label}
+              label={label}
+              value={value}
+              secondaryValue={secondaryValue}
+            />
           ))}
         </Box>
         {shouldShowEndChatButton && (
@@ -39,6 +45,7 @@ export default function ChatboxHeader({
             sx={{
               alignSelf: 'center',
               minWidth: 'auto',
+              flexShrink: 0,
               px: 1.75,
               py: 0.75,
               backgroundColor: 'rgba(255, 255, 255, 0.24)',
@@ -56,14 +63,42 @@ export default function ChatboxHeader({
   );
 }
 
-function RowForHeader({ label, value }: HeaderRow): JSX.Element {
+function RowForHeader({
+  label,
+  value,
+  secondaryValue,
+}: HeaderRow): JSX.Element {
   return (
-    <Box sx={{ display: 'flex', gap: 0.5 }}>
-      <Typography variant='body2' sx={{ color: 'neutrals.200' }}>
+    <Box sx={{ display: 'flex', gap: 0.5, minWidth: 0 }}>
+      <Typography
+        component='span'
+        variant='body2'
+        sx={{ color: 'neutrals.200', flexShrink: 0 }}
+      >
         {label}
       </Typography>
-      <Typography variant='body2' sx={{ color: 'neutrals.white' }}>
+      <Typography
+        component='span'
+        variant='body2'
+        sx={{
+          color: 'neutrals.white',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          minWidth: 0,
+        }}
+      >
         {value}
+        {secondaryValue && (
+          <Typography
+            component='span'
+            variant='body2'
+            sx={{ color: 'neutrals.200' }}
+          >
+            {' '}
+            ({secondaryValue})
+          </Typography>
+        )}
       </Typography>
     </Box>
   );

--- a/src/components/shared/ChatboxHeader.tsx
+++ b/src/components/shared/ChatboxHeader.tsx
@@ -83,7 +83,6 @@ function RowForHeader({
         sx={{
           color: 'neutrals.white',
           overflow: 'hidden',
-          textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
           minWidth: 0,
         }}


### PR DESCRIPTION
Part of #323 

Updated Students page chatbox header to show students real names if it has it.

Desktop:
<img width="681" height="561" alt="image" src="https://github.com/user-attachments/assets/7f8a8fa9-7580-4da3-bb61-ed6bbfc237c2" />

Mobile:
<img width="411" height="326" alt="image" src="https://github.com/user-attachments/assets/22294900-a7ce-4148-8fad-37cf5321c69b" />